### PR TITLE
Add categories page

### DIFF
--- a/scripts/compile-html.mjs
+++ b/scripts/compile-html.mjs
@@ -51,7 +51,11 @@ const writeFiles = () => {
   }
 
   const routes = collectRoutes();
-  const baseURL = process.env.BASE_URL || "";
+  let baseURL = process.env.BASE_URL || "/";
+  // Trim ending slash, we append our own everywhere
+  if (baseURL.endsWith("/")) {
+    baseURL = baseURL.substring(0, baseURL.length - 1);
+  }
 
   routes.forEach((route) => {
     const doctype = route === "sitemap" ? "xml" : "html";

--- a/src/router.js
+++ b/src/router.js
@@ -24,7 +24,37 @@ const getPugFile = (route) => {
  */
 const categoriesRouter = (route, context) => {
   if (route === "/categories") {
-    console.log("categories");
+    const entryList = Object.keys(context.entries).map(
+      (entrySlug) => context.entries[entrySlug]
+    );
+    const sampleCategories = [];
+    Object.keys(context.categories).forEach((categorySlug) => {
+      const sampleEntry =
+        entryList.find((entry) => {
+          // Find an entry that is not already in the sample list
+          return (
+            entry.categorySlugs.includes(categorySlug) &&
+            !sampleCategories.find((sample) => sample.entrySlug === entry.slug)
+          );
+        }) ||
+        // If unable to find one, fall back to duplicate entry
+        entryList.find((entry) => {
+          return entry.categorySlug.includes(categorySlug);
+        });
+      let numVideos = 0;
+      entryList.forEach((entry) => {
+        if (entry.categorySlugs.includes(categorySlug)) {
+          numVideos++;
+        }
+      });
+      sampleCategories.push({
+        entrySlug: sampleEntry.slug,
+        categorySlug,
+        numVideos,
+      });
+    });
+    const pugFile = getPugFile("categories");
+    return pug.renderFile(pugFile, { ...context, sampleCategories });
   }
   return null;
 };

--- a/src/router.js
+++ b/src/router.js
@@ -5,34 +5,45 @@ const { getContext } = require("./context");
 
 const VIEW_ROOT_DIR = path.join(__dirname, "views");
 
+const getPugFile = (route) => {
+  return path.join(VIEW_ROOT_DIR, `${route}.pug`);
+};
+
 /**
  * A Router checks the given route, and if it can handle that route it returns a string of rendered
  * HTML contents.
  *
  * @callback Router
  * @param {string} route
- * @param {Object} options
+ * @param {Object} context
  * @returns {string | null}
  */
+
+/**
+ * @type {Router}
+ */
+const categoriesRouter = (route, context) => {
+  if (route === "/categories") {
+    console.log("categories");
+  }
+  return null;
+};
 
 /**
  * Tries to match the given route to a pug file by its path on the filesystem.
  *
  * @type {Router}
  */
-const pugFileRouter = (route, options) => {
+const pugFileRouter = (route, context) => {
   let pugFile;
-  if (fs.existsSync(path.join(VIEW_ROOT_DIR, `${route}.pug`))) {
-    pugFile = path.join(VIEW_ROOT_DIR, `${route}.pug`);
-  } else if (fs.existsSync(path.join(VIEW_ROOT_DIR, route, "index.pug"))) {
-    pugFile = path.join(VIEW_ROOT_DIR, route, "index.pug");
+  if (fs.existsSync(getPugFile(route))) {
+    pugFile = getPugFile(route);
+  } else if (fs.existsSync(getPugFile(`${route}/index`))) {
+    pugFile = getPugFile(`${route}/index`);
   }
 
   if (pugFile) {
-    return pug.renderFile(pugFile, {
-      ...options,
-      ...getContext(),
-    });
+    return pug.renderFile(pugFile, context);
   }
 
   return null;
@@ -41,16 +52,14 @@ const pugFileRouter = (route, options) => {
 /**
  * @type {Router}
  */
-const brandRouter = (route, options) => {
+const brandRouter = (route, context) => {
   const match = route.match(/brand\/([A-z0-9-]+)\/?/);
   if (match) {
     const matchingId = match[1];
-    const context = getContext();
     const selectedBrand = context.brands[matchingId];
     if (selectedBrand) {
-      const pugFile = path.join(VIEW_ROOT_DIR, "slugged", "brand.pug");
+      const pugFile = getPugFile("slugged/brand");
       return pug.renderFile(pugFile, {
-        ...options,
         ...context,
         brand: selectedBrand,
       });
@@ -63,16 +72,14 @@ const brandRouter = (route, options) => {
 /**
  * @type {Router}
  */
-const categoryRouter = (route, options) => {
+const categoryRouter = (route, context) => {
   const match = route.match(/category\/([A-z0-9-]+)\/?/);
   if (match) {
     const matchingId = match[1];
-    const context = getContext();
     const selectedCategory = context.categories[matchingId];
     if (selectedCategory) {
-      const pugFile = path.join(VIEW_ROOT_DIR, "slugged", "category.pug");
+      const pugFile = getPugFile("slugged/category");
       return pug.renderFile(pugFile, {
-        ...options,
         ...context,
         category: selectedCategory,
       });
@@ -88,11 +95,10 @@ const categoryRouter = (route, options) => {
  *
  * @type {Router}
  */
-const viewEntryRouter = (route, options) => {
+const viewEntryRouter = (route, context) => {
   const match = route.match(/view\/([A-z0-9-]+)\/?/);
   if (match) {
     const matchingId = match[1];
-    const context = getContext();
     const selectedEntry = context.entries[matchingId];
     if (selectedEntry) {
       const brand = context.brands[selectedEntry.brandSlug];
@@ -111,9 +117,8 @@ const viewEntryRouter = (route, options) => {
       const sidebarVideos = recommendedSection.entries
         .slice(0, 5)
         .map((entrySlug) => context.entries[entrySlug]);
-      const pugFile = path.join(VIEW_ROOT_DIR, "slugged", "view.pug");
+      const pugFile = getPugFile("slugged/view");
       return pug.renderFile(pugFile, {
-        ...options,
         ...context,
         entry: selectedEntry,
         brand,
@@ -138,6 +143,7 @@ const routerPipe =
   (routers) =>
   (route, options = {}) => {
     const baseOptions = {
+      ...getContext(),
       baseURL: "",
     };
     for (const router of routers) {
@@ -150,6 +156,7 @@ const routerPipe =
   };
 
 const appRouter = routerPipe([
+  categoriesRouter,
   pugFileRouter,
   brandRouter,
   categoryRouter,

--- a/src/router.js
+++ b/src/router.js
@@ -108,10 +108,14 @@ const categoryRouter = (route, context) => {
     const matchingId = match[1];
     const selectedCategory = context.categories[matchingId];
     if (selectedCategory) {
+      const filteredEntries = Object.keys(context.entries)
+        .map((entrySlug) => context.entries[entrySlug])
+        .filter((entry) => entry.categorySlugs.includes(matchingId));
       const pugFile = getPugFile("slugged/category");
       return pug.renderFile(pugFile, {
         ...context,
         category: selectedCategory,
+        filteredEntries,
       });
     }
   }

--- a/src/styles/main.sass
+++ b/src/styles/main.sass
@@ -3,14 +3,22 @@
 @import variables
 
 @import mixins/card
+@import mixins/entry-image
 
+@import views/categories
+@import views/category
 @import views/index
 @import views/view
+
+html,
+body
+  min-height: 100%
 
 body
   font: 100%
   background: $background
-  display: grid
+  display: flex
+  flex-direction: column
   color: #fff
 
 h1

--- a/src/styles/mixins/card.sass
+++ b/src/styles/mixins/card.sass
@@ -28,30 +28,25 @@
     position: relative
     background-color: $video-loading-color
 
-    &:hover::after
-      @keyframes loadingIndicator
-        from
-          right: 100%
-        to
-          right: 0
-      animation-duration: 0.5s
-      animation-name: loadingIndicator
+    &.loadable
+      &:hover::after
+        @keyframes loadingIndicator
+          from
+            right: 100%
+          to
+            right: 0
+        animation-duration: 0.5s
+        animation-name: loadingIndicator
 
-    &::after
-      content: ""
-      position: absolute
-      background: $primary-color
-      left: 0
-      right: 100%
-      top: 0
-      height: 4px
-      transition: all 0s
-      transition-timing-function: linear
-      overflow: hidden
+      &::after
+        content: ""
+        position: absolute
+        background: $primary-color
+        left: 0
+        right: 100%
+        top: 0
+        height: 4px
+        transition: all 0s
+        transition-timing-function: linear
+        overflow: hidden
 
-    img
-      width: 100%
-      height: auto
-
-      &.inverted
-        transform: scaleX(-1)

--- a/src/styles/mixins/entry-image.sass
+++ b/src/styles/mixins/entry-image.sass
@@ -1,0 +1,6 @@
+img
+  width: 100%
+  height: auto
+
+  &.inverted
+    transform: scaleX(-1)

--- a/src/styles/partials.sass
+++ b/src/styles/partials.sass
@@ -4,6 +4,7 @@
   background-color: #1b1b1b
   width: 100%
   z-index: 99
+  flex: 0
 
   .flex-container
     display: flex

--- a/src/styles/views/categories.sass
+++ b/src/styles/views/categories.sass
@@ -7,12 +7,9 @@
     align-content: center
     grid-template-rows: auto
     grid-template-columns: repeat(4, 1fr)
-    grid-row-gap: 16px
+    grid-row-gap: 32px
     grid-column-gap: 16px
     padding: 20px 0
-
-    @media screen and (min-width: 1200px)
-        grid-template-columns: repeat(5, 1fr)
 
     .card
       position: relative

--- a/src/styles/views/categories.sass
+++ b/src/styles/views/categories.sass
@@ -1,0 +1,36 @@
+@import "../variables"
+    
+.content-categories
+  .card-grid
+    display: grid
+    justify-content: center
+    align-content: center
+    grid-template-rows: auto
+    grid-template-columns: repeat(4, 1fr)
+    grid-row-gap: 16px
+    grid-column-gap: 16px
+    padding: 20px 0
+
+    @media screen and (min-width: 1200px)
+        grid-template-columns: repeat(5, 1fr)
+
+    .card
+      position: relative
+
+      .category-overlay
+        position: absolute
+        left: 0
+        top: 0
+        width: 100%
+        height: 100%
+        background: linear-gradient(to bottom,rgba(0,0,0,0) 0,rgba(0,0,0,.5) 100%)
+
+      .category-info
+        position: absolute
+        left: 8px
+        bottom: 8px
+        color: white
+
+        p
+          color: #c8c8c8
+          margin: 0

--- a/src/styles/views/category.sass
+++ b/src/styles/views/category.sass
@@ -1,0 +1,15 @@
+@import "../variables"
+    
+.content-category
+  .card-grid
+    display: grid
+    justify-content: center
+    align-content: center
+    grid-template-rows: auto
+    grid-template-columns: repeat(4, 1fr)
+    grid-row-gap: 16px
+    grid-column-gap: 16px
+    padding: 20px 0
+
+    @media screen and (min-width: 1200px)
+        grid-template-columns: repeat(5, 1fr)

--- a/src/views/categories.pug
+++ b/src/views/categories.pug
@@ -1,9 +1,21 @@
 extends ./partials/layout
+include ./mixins/card
 
 append config
   - var pageTitle = "Categories"
 
 block body
-  div.content
+  div.content.content-categories
     h1.title Categories
-    p Work in progress...
+    ul.card-grid
+      each sample in sampleCategories
+        - const entry = entries[sample.entrySlug]
+        - const categoryURL = `${baseURL}/category/${sample.categorySlug}`
+        li.card
+          a(href=categoryURL)
+            div.card-image-wrapper
+              +entry-image(entry)
+            .category-overlay
+            .category-info
+              h2= categories[sample.categorySlug].name
+              p= sample.numVideos + " videos"

--- a/src/views/mixins/card.pug
+++ b/src/views/mixins/card.pug
@@ -1,11 +1,11 @@
+include ./entry-image
+
 mixin card(entry, horizontal)
   - const entryURL = `${baseURL}/view/${entry.slug}`
   li.card(class={"card-horizontal": horizontal})
     a(href=entryURL)
-      div.card-image-wrapper
-        - const imgPath = `${baseURL}/assets/img/noods/${entry.picture.fileName}`
-        - const minImgPath = `${baseURL}/assets/img/noods/min/${entry.picture.fileName}`
-        img(src=minImgPath, alt=entry.title, class={ "inverted": entry.picture.invert }, srcset=`${minImgPath}, ${imgPath}`)
+      div.card-image-wrapper.loadable
+        +entry-image(entry)
     .card-info
       div.card-title
         a(href=entryURL)= entry.title

--- a/src/views/mixins/entry-image.pug
+++ b/src/views/mixins/entry-image.pug
@@ -1,0 +1,4 @@
+mixin entry-image(entry, horizontal)
+  - const imgPath = `${baseURL}/assets/img/noods/${entry.picture.fileName}`
+  - const minImgPath = `${baseURL}/assets/img/noods/min/${entry.picture.fileName}`
+  img(src=minImgPath, alt=entry.title, class={ "inverted": entry.picture.invert }, srcset=`${minImgPath}, ${imgPath}`)

--- a/src/views/slugged/category.pug
+++ b/src/views/slugged/category.pug
@@ -1,9 +1,12 @@
 extends ../partials/layout
+include ../mixins/card
 
 append config
   - var pageTitle = category.name
 
 block body
   div.content.content-category
-    p Placeholder for category #{category.name}
-    p Work in progress...
+    h1.title= category.name
+    ul.card-grid
+      each entry in filteredEntries
+        +card(entry)


### PR DESCRIPTION
**Changes:**
- Consolidated all pugfile resolution to a single helper method
- Added a new router for the `/categories` page that samples an entry for each category as the thumbnail, and renders a count of videos under that category
- Replaced all occurrences of `options` with `context` in the router
- Finished styling on the `categories` and `category` views

**Preview:**
![image](https://user-images.githubusercontent.com/10366495/160031914-4ed050dd-b90e-4ccd-9b1c-83d405354882.png)
