### PR TITLE
Add footer

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 
 env:
-  BASE_URL: "" # Match this to the base URL of your GitHub pages
+  BASE_URL: "https://nood.pictures" # Match this to the base URL of your GitHub pages
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Spicy noodle pictures",
   "main": "compile.js",
   "scripts": {
-    "serve": "ts-node-dev --files ./scripts/serve",
+    "serve": "ts-node-dev --files -- ./scripts/serve",
     "build": "npm run clean && npm run build:assets && npm run build:data && npm run build:sass && npm run build:html",
     "clean": "ts-node ./scripts/clean",
-    "build:assets": "ts-node ./scripts/copy-assets",
-    "build:data": "ts-node  --files ./scripts/generate-data",
-    "build:html": "ts-node --files ./scripts/compile-html",
+    "build:assets": "ts-node -- ./scripts/copy-assets",
+    "build:data": "ts-node  --files -- ./scripts/generate-data",
+    "build:html": "ts-node --files -- ./scripts/compile-html",
     "build:sass": "node-sass src/styles/main.sass -o dist/styles --output-style compressed"
   },
   "author": "Peter Abbondanzo",

--- a/scripts/compile-html.ts
+++ b/scripts/compile-html.ts
@@ -20,6 +20,14 @@ const collectRoutes = () => {
   const dataFile = fs.readFileSync(dataOutputFile).toString("utf-8");
   const rawData: Data = JSON.parse(dataFile);
 
+  // All /information/ routes
+  routes.push(
+    ...fs
+      .readdirSync(path.join(VIEWS_DIR, "information"))
+      .filter((file) => file.endsWith(".pug"))
+      .map((view) => "/" + view.replace(/\.pug$/, ""))
+  );
+
   // All /view/entrySlug routes
   routes.push(
     ...Object.keys(rawData.entries).map((entrySlug) => `/view/${entrySlug}`)

--- a/scripts/compile-html.ts
+++ b/scripts/compile-html.ts
@@ -25,7 +25,7 @@ const collectRoutes = () => {
     ...fs
       .readdirSync(path.join(VIEWS_DIR, "information"))
       .filter((file) => file.endsWith(".pug"))
-      .map((view) => "/" + view.replace(/\.pug$/, ""))
+      .map((view) => "/information/" + view.replace(/\.pug$/, ""))
   );
 
   // All /view/entrySlug routes
@@ -62,8 +62,8 @@ const writeFiles = () => {
   }
 
   routes.forEach((route) => {
-    const doctype = route === "sitemap" ? "xml" : "html";
-    const html = appRouter(route, { pretty: true, doctype, baseURL });
+    const doctype = route === "/sitemap" ? "xml" : "html";
+    const html = appRouter(route, { pretty: true, doctype, baseURL, routes });
 
     if (!html) {
       console.log(`No HTML content served by route ${route}. Skipping...`);

--- a/scripts/serve.ts
+++ b/scripts/serve.ts
@@ -22,7 +22,9 @@ const createPugServer = (): ChainableHandler => {
     try {
       const maybePugRendered = appRouter(req.url);
       if (maybePugRendered) {
-        res.writeHead(200, { "Content-Type": "text/html" });
+        res.writeHead(200, {
+          "Content-Type": req.url === "/sitemap" ? "text/xml" : "text/html",
+        });
         res.end(maybePugRendered);
         return true;
       }

--- a/src/router.ts
+++ b/src/router.ts
@@ -14,10 +14,14 @@ import { Context, Router } from "./routers/_type";
  */
 const routerPipe =
   (routers: Router[]) =>
-  (route: string, options: pug.Options & { baseURL?: string } = {}) => {
+  (
+    route: string,
+    options: pug.Options & { baseURL?: string; routes?: string[] } = {}
+  ) => {
     const baseOptions: Context = {
       ...getContext(),
       baseURL: "",
+      routes: [],
     };
     for (const router of routers) {
       const routerResult = router(route, { ...baseOptions, ...options });

--- a/src/routers/_type.ts
+++ b/src/routers/_type.ts
@@ -1,6 +1,11 @@
 import pug from "pug";
 
-export type Context = Data & pug.Options & { baseURL: string };
+interface Extras {
+  baseURL: string;
+  routes: string[];
+}
+
+export type Context = Data & pug.Options & Extras;
 
 /**
  * A Router checks the given route, and if it can handle that route it returns a string of rendered

--- a/src/styles/main.sass
+++ b/src/styles/main.sass
@@ -14,7 +14,7 @@
 
 html,
 body
-  min-height: 100%
+  min-height: 100vh
 
 body
   font: 100%

--- a/src/styles/main.sass
+++ b/src/styles/main.sass
@@ -9,6 +9,7 @@
 @import views/categories
 @import views/category
 @import views/index
+@import views/information
 @import views/noodstars
 @import views/view
 

--- a/src/styles/partials.sass
+++ b/src/styles/partials.sass
@@ -71,3 +71,37 @@
 
             &::before
               right: 0
+
+#body-main
+  flex: 1
+
+#footer
+  background-color: #1b1b1b
+
+  .content
+    display: grid
+    justify-content: center
+    align-content: center
+    grid-template-columns: repeat(3, 1fr)
+    grid-column-gap: 16px
+    padding: 20px 0
+
+  .footer-block
+    color: #aaa
+
+    li
+      margin-bottom: 8px
+
+    a
+      color: $primary-color
+      font-size: 14px
+
+      &:hover
+        text-decoration: underline
+
+.post-footer
+  padding: 16px
+
+  .copyright
+    text-align: center
+    color: #666

--- a/src/styles/views/information.sass
+++ b/src/styles/views/information.sass
@@ -1,0 +1,21 @@
+@import "../variables"
+
+.information-page
+  font-size: 18px
+
+  h2
+    margin: 16px 0
+    
+  p
+    font-size: 18px
+    margin: 16px 0
+
+  a
+    color: $primary-color
+
+    &:hover
+      text-decoration: underline
+
+  ul
+    list-style: inherit
+    padding-left: 1em

--- a/src/views/information/contact-support.pug
+++ b/src/views/information/contact-support.pug
@@ -1,0 +1,9 @@
+extends ../partials/layout
+
+append config
+  - var pageTitle = "Contact Support"
+
+block body
+  div.content
+    h1.title Contact Support
+    p Work in progress...

--- a/src/views/information/dmca.pug
+++ b/src/views/information/dmca.pug
@@ -1,0 +1,9 @@
+extends ../partials/layout
+
+append config
+  - var pageTitle = "DMCA"
+
+block body
+  div.content
+    h1.title DMCA
+    p Work in progress...

--- a/src/views/information/faq.pug
+++ b/src/views/information/faq.pug
@@ -1,0 +1,9 @@
+extends ../partials/layout
+
+append config
+  - var pageTitle = "FAQ"
+
+block body
+  div.content
+    h1.title FAQ
+    p Work in progress...

--- a/src/views/information/feedback.pug
+++ b/src/views/information/feedback.pug
@@ -1,0 +1,9 @@
+extends ../partials/layout
+
+append config
+  - var pageTitle = "Feedback"
+
+block body
+  div.content
+    h1.title Feedback
+    p Work in progress...

--- a/src/views/information/parental-controls.pug
+++ b/src/views/information/parental-controls.pug
@@ -1,0 +1,9 @@
+extends ../partials/layout
+
+append config
+  - var pageTitle = "Parental Controls"
+
+block body
+  div.content
+    h1.title Parental Controls
+    p Work in progress...

--- a/src/views/information/privacy-policy.pug
+++ b/src/views/information/privacy-policy.pug
@@ -1,0 +1,9 @@
+extends ../partials/layout
+
+append config
+  - var pageTitle = "Privacy Policy"
+
+block body
+  div.content
+    h1.title Privacy Policy
+    p Work in progress...

--- a/src/views/information/privacy-policy.pug
+++ b/src/views/information/privacy-policy.pug
@@ -4,6 +4,26 @@ append config
   - var pageTitle = "Privacy Policy"
 
 block body
-  div.content
+  div.content.information-page
     h1.title Privacy Policy
-    p Work in progress...
+    span Last modified #{new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+    p I respect your privacy so much that I will not collect any information about you. I am committed to protecting your personal data because #[strike I am too lazy to set up analytics and trackers] I believe that no one should be alienated and targeted for their spicy noodle addictions.
+    h2 What information Nood.Pictures collects
+    p None
+    h2 How Nood.Pictures uses your Information
+    p We don't. But if you send us your information in a PR or via the email address linked on #[a.color-primary(href="https://github.com/Abbondanzo/") a certain GitHub profile], here are some of the things that we #[i could] do with it:
+    ul
+      li Commit tax fraud
+      li Squat domains related to your surname 
+      li Find your mother on Whitepages and call her up to tell you that you're a nice person
+        ul
+          li Alternatively, we could tell another family member
+      li Subscribe you to random mailing lists once per month, but the kind that say "Your email will be removed from this mailing list in the next 24 hours" when you try to unsubscribe, thereby leaving you unsure if you've actually been unsubscribed or not but you still keep getting emails from them. Because it's not like they #[i can't] remove your email from that list immediately, they're just incredibly shady.
+    h2 How we share the information we collect
+    p Again, we don't collect information in the first place
+    h2 How you can access and control the information we collect
+    p You can't. It's ours now forever
+    h2 Are you just ripping off other Privacy Policy agreements to fill this page with filler content?
+    p Yes, that is exactly what I'm doing. I am not a lawyer, so who am I not to appreciate the work that other lawyers have done?
+    h2 Do you think God stays in heaven because He too lives in fear of what He has created?
+    p Yes, #[a(href="https://www.youtube.com/watch?v=0fPRO2SApO8") Steve Buscemi], yes I do

--- a/src/views/information/terms-and-conditions.pug
+++ b/src/views/information/terms-and-conditions.pug
@@ -4,6 +4,14 @@ append config
   - var pageTitle = "Terms and Conditions"
 
 block body
-  div.content
+  div.content.information-page
     h1.title Terms and Conditions
-    p Work in progress...
+    span Last modified #{new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+    p By accessing, using, or visiting #[a(href=baseURL)= baseURL] (the "Website"), any of its amazing content, crappy functionality, and seemingly anything else we've made for it along the way, you have unknowingly and without choice have signified your agreement to these terms and conditions.
+    p This site is a parody, it's entirely fictional. Even content that is based on real life is coincidental. I am not responsible for any content that violates community standards in your community.
+    p Isn't it quite wild how websites will just list this as their terms and conditions? It's like if you walked into a restaurant and they were like, "Welp, you knowingly walked into here so you've agreed to share with us all of your browsing history. Oh, you don't want to? Well you can't eat here."
+    p We know it's not a fair comparison, but then again it's a liability/"don't be an asshole" thing. It's the same reason a library can and should be able to kick you out for being a loud jerk. Just because you #[i can] be an asshole doesn't mean you should.
+    p And look, here's the reality of this website. I don't care what you do with it. Scrape all of its data and host your own version of it. Access it as much as you'd like for as long as you'd like. Everything is hosted on GitHub Pages anyhow so I'm not paying for bandwidth. Want to DDoS this site? Have at it.
+    p Something something #[i cookies], something something #[i user security]. It's a static site, there's none of that here. I tried to build as much of this thing as best as I could with a templating engine so that you don't have to load a single line of JavaScript, but then I realized I wanted to add a few funny features with scripts so that didn't pan out fully. There are no user accounts because everything works through GitHub (oh look, I'm repeating myself) so if you want a terms and conditions to agree to, #[a(href="https://docs.github.com/en/site-policy/github-terms/github-terms-of-service") do it there].
+    p I will say this, however: if you make any PRs to upload content or fix anything, be considerate and intentional. Send me vague pictures of your favorite noodles but I don't care what your pets look like, or about that family photo from a trip that you went on in 2013.
+    p I wrote all of this out just as filler. I wanted to make it look official and scary and I think I succeeded. So if you made it this far, I commend your efforts and I want to reword you for you hard work. Click #[a(href="https://www.youtube.com/watch?v=nn5q38-5ZLQ") here] for your reward.

--- a/src/views/information/terms-and-conditions.pug
+++ b/src/views/information/terms-and-conditions.pug
@@ -1,0 +1,9 @@
+extends ../partials/layout
+
+append config
+  - var pageTitle = "Terms and Conditions"
+
+block body
+  div.content
+    h1.title Terms and Conditions
+    p Work in progress...

--- a/src/views/partials/footer.pug
+++ b/src/views/partials/footer.pug
@@ -1,0 +1,39 @@
+mixin footerLinksList(links)
+  ul
+    each link in links
+      li
+        - var qualifiedURL = link.path.startsWith("/") ? `${baseURL}${link.path}` : link.path
+        a(href=qualifiedURL)= link.name
+
+#footer
+  .content
+    .footer-block
+      h3 Information
+      - 
+        var links = [
+          {path: "/information/terms-and-conditions", name: "Terms & Conditions"},
+          {path: "/information/privacy-policy", name: "Privacy Policy"},
+          {path: "/information/dmca", name: "DMCA"},
+        ]
+      +footerLinksList(links)
+    .footer-block
+      h3 Support
+      - 
+        var links = [
+          {path: "/information/faq", name: "FAQ"},
+          {path: "/information/contact-support", name: "Contact Support"},
+          {path: "/information/feedback", name: "Feedback"},
+          {path: "/information/parental-controls", name: "Parental Controls"},
+        ]
+      +footerLinksList(links)
+    .footer-block
+      h3 Discover
+      ul
+        li 
+          a(href="#") Visually Impaired
+        li
+          a(href="#") Shop
+        li
+          a(href="https://github.com/Abbondanzo/noodles") GitHub
+.post-footer.content
+  .copyright Not &copy; Nood.pictures #{new Date().getFullYear()}

--- a/src/views/partials/footer.pug
+++ b/src/views/partials/footer.pug
@@ -11,6 +11,7 @@ mixin footerLinksList(links)
       h3 Information
       - 
         var links = [
+          {path: "/sitemap", name: "Sitemap"},
           {path: "/information/terms-and-conditions", name: "Terms & Conditions"},
           {path: "/information/privacy-policy", name: "Privacy Policy"},
           {path: "/information/dmca", name: "DMCA"},

--- a/src/views/partials/layout.pug
+++ b/src/views/partials/layout.pug
@@ -8,4 +8,6 @@ html(lang="en")
       include ./meta-head
   body
     include ./navbar
-    block body
+    #body-main
+      block body
+    include ./footer

--- a/src/views/partials/meta-head.pug
+++ b/src/views/partials/meta-head.pug
@@ -1,5 +1,4 @@
 - var title = `${pageTitle ? `${pageTitle} | ` : ''} Nood Pictures`
-- var fullURL = `https://nood.pictures`
 
 title=title
 meta(name="description" content=description)
@@ -11,7 +10,7 @@ link(rel="icon" type="image/png" sizes="16x16" href=`${baseURL}/assets/img/favic
 link(rel="shortcut icon" href=`${baseURL}/assets/img/favicon.ico`)
 meta(name="msapplication-TileColor" content="#000000")
 meta(name="msapplication-config" content=`${baseURL}/assets/img/browserconfig.xml`)
-meta(property="og:image" content=`${fullURL}${ogImagePath}`)
+meta(property="og:image" content=`${baseURL}${ogImagePath}`)
 meta(property="og:image:alt" content="Spicy noods")
 meta(property="og:title" content=title)
 meta(property="og:type" content="website")

--- a/src/views/sitemap.pug
+++ b/src/views/sitemap.pug
@@ -1,0 +1,15 @@
+doctype xml
+
+urlset(
+  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+)
+  each path, index in routes
+    url
+      loc= baseURL + path
+      if index === 0
+        priority= '1.00'
+      else
+        priority= '0.80'
+      lastmod= new Date().toISOString()


### PR DESCRIPTION
**Changes**
- Set the `BASE_URL` environment variable to the current custom domain. This way, all assets that require absolute paths will be able to resolve them (like `og:image`) without hard-coding the domain everywhere
- Added more routes under the `information` slug based on the `information` folder
- Fixed sitemap generation and dev server response type to properly yield XML files
- Added routes to the `Context` extras type so other pug templates can use them
- Fixed the body size so it's always a minimum of the entire view height, thereby always showing the footer at the bottom of the client or beyond the fold

**Preview**
![image](https://user-images.githubusercontent.com/10366495/160265513-9351bbf5-eec0-43a5-88a6-046706ff4532.png)
